### PR TITLE
add datadog as a monitoring tool with kubernetes support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ A curated list of amazingly awesome resources for ``Kubernetes`` and its eco-sys
 - [Heapster](https://github.com/kubernetes/heapster)
 - [Prometheus](http://prometheus.io)
 - [Sysdig](http://www.sysdig.org/)
+- [Datadog](http://www.datadoghq.com)
 
 ## Resources
 - [Key Concepts](http://blog.arungupta.me/key-concepts-kubernetes/)


### PR DESCRIPTION
add datadog as a monitoring tool with kubernetes support
https://www.datadoghq.com/blog/corral-your-docker-containers-with-kubernetes-monitoring/
